### PR TITLE
update documentation

### DIFF
--- a/github-actions/index.md
+++ b/github-actions/index.md
@@ -23,7 +23,8 @@ jobs:
         with:
           to: "example@example.com"
           subject: "building main"
-          body: "This is a notification from GitHub actions."
+          body: "<em>This is a notification from GitHub actions.</em>"
+          type: "text/html"
 ```
 
 There is also the [starter template](https://github.com/cinotify/github-actions-example) which can be used as a starting point for setting up a GitHub Actions Workflow with email notifications.

--- a/http/index.md
+++ b/http/index.md
@@ -12,12 +12,13 @@ The HTTP API is how emails are sent from Continuous Integration environments.
 
 ### Parameters
 
-| name        | type   | required |
-| ----------- | ------ | -------- |
-| to          | string | true     |
-| subject     | string | true     |
-| body        | string | false    |
-| attachments | array  | false    |
+| name        | type   | required                      |
+| ----------- | ------ | ----------------------------- |
+| to          | string | true                          |
+| subject     | string | true                          |
+| body        | string | false (default: ' ')          |
+| attachments | array  | false (default: undefined)    |
+| type        | string | false (default: 'text/plain') |
 
 #### Attachments
 
@@ -52,5 +53,18 @@ curl -X POST 'https://www.cinotify.cc/api/notify' \
         "filename": "hello.txt"
       }
     ]
+  }'
+```
+
+#### HTML Email
+
+```bash
+curl -X POST 'https://www.cinotify.cc/api/notify' \
+  -H "Content-Type: application/json" \
+  -d '{
+    "body": "<em>hello</em>",
+    "subject": "example html email",
+    "to": "example@example.com",
+    "type": "text/html"
   }'
 ```

--- a/index.md
+++ b/index.md
@@ -13,5 +13,5 @@ Typically, continuous integration tests and builds run within a docker container
 
 ```bash
 curl --request POST 'https://www.cinotify.cc/api/notify' \
-  -d "to=example@example.com&subject=building main&body=hello.&attachments[][type]=text/plain&attachments[][content]=aGVsbG8sIHdvcmxkIQ==&attachments[][filename]=hello.txt"
+  -d "to=example@example.com&subject=email body&body=<em>hello</em>.&type=text/html&attachments[][type]=text/plain&attachments[][content]=aGVsbG8sIHdvcmxkIQ==&attachments[][filename]=hello.txt"
 ```


### PR DESCRIPTION
to include `text/html` `type` support for sending html emails